### PR TITLE
feature(게시물 상세 조회): 수정, 삭제 버튼 생성, 및 useParams 함수 타입 수정.

### DIFF
--- a/src/Article/argumentsPropsInterface/ArticleProps.tsx
+++ b/src/Article/argumentsPropsInterface/ArticleProps.tsx
@@ -1,11 +1,21 @@
-import { RouteComponentProps } from 'react-router-dom';
-import { ArticleCommentApi, ArticleCreateApi } from '../../api/ApiProps';
+import {
+  ArticleCommentApi,
+  ArticleCreateApi,
+  ArticleDetailApi,
+} from '../../api/ApiProps';
 
 export interface CommentAreaProps {
   onRegisterComment: (newComment: ArticleCommentApi) => void;
   onPressFavorite: (targetComment: ArticleCommentApi) => void;
   commentsListProps: ArticleCommentApi[];
 }
+
 export interface ArticleCreatePageProps {
   onRegisterArticle: (newArticle: ArticleCreateApi) => void;
+}
+
+export interface ArticleHeaderProps {
+  onUpdateArticle: () => void;
+  onDeleteArticle: () => void;
+  articleData: ArticleDetailApi;
 }

--- a/src/Article/container/ArticleHeaderContainer.tsx
+++ b/src/Article/container/ArticleHeaderContainer.tsx
@@ -7,18 +7,21 @@ const ArticleHeaderContainer = () => {
   // this is for api procedures.
   const articleData = articleAPI.get();
 
+  const onUpdateArticle = () => {
+    console.log('update btn clicked!');
+    // 게시물 업데이트 기능을 여기에 구현하면 됩니다. (너무친절)
+  };
+
+  const onDeleteArticle = () => {
+    console.log('delete btn clicked!');
+    // 게시물 삭제 기능을 여기에 구현하면 됩니다. (너무친절)
+  };
+
   return (
     <ArticleHeader
-      options={articleData.options}
-      title={articleData.title}
-      anonymous={articleData.anonymous}
-      createdDate={articleData.createdDate}
-      author={articleData.author}
-      content={articleData.content}
-      hashtags={articleData.hashtags}
-      favorites={articleData.favorites}
-      wonders={articleData.wonders}
-      clips={articleData.clips}
+      onUpdateArticle={onUpdateArticle}
+      onDeleteArticle={onDeleteArticle}
+      articleData={articleData}
     />
   );
 };

--- a/src/Article/presentational/ArticleDetail.tsx
+++ b/src/Article/presentational/ArticleDetail.tsx
@@ -8,7 +8,7 @@ import FloatingButton from './FloatingButton';
 import '../css/FloatingButton.css';
 
 const ArticleDetailContainer = () => {
-  const { id } = useParams();
+  const { id } = useParams<{ id: string }>();
   const history = useHistory();
   console.log(id, history);
   return (

--- a/src/Article/presentational/ArticleHeader.tsx
+++ b/src/Article/presentational/ArticleHeader.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { ArticleDetailApi } from '../../api/ApiProps';
+import { ArticleHeaderProps } from '../argumentsPropsInterface/ArticleProps';
 
-const ArticleHeader = (dummyData: ArticleDetailApi) => {
-  const { options, title, anonymous, createdDate, author } = { ...dummyData };
+const ArticleHeader = ({
+  onUpdateArticle,
+  onDeleteArticle,
+  articleData,
+}: ArticleHeaderProps) => {
+  const { options, title, anonymous, createdDate, author } = { ...articleData };
   const createdTimeFormat = `${createdDate.slice(0, 4)}-${createdDate.slice(
     4,
     6
@@ -18,6 +22,22 @@ const ArticleHeader = (dummyData: ArticleDetailApi) => {
       <div className="article-detail">
         {anonymous ? <div>익명</div> : <div>{author.name}</div>}
         <time className="article-created-time">{createdTimeFormat}</time>
+      </div>
+      <div className="articleheader-btns">
+        <button
+          type="button"
+          className="articleheade-btn-update"
+          onClick={onUpdateArticle}
+        >
+          수정
+        </button>
+        <button
+          type="button"
+          className="articleheade-btn-delete"
+          onClick={onDeleteArticle}
+        >
+          삭제
+        </button>
       </div>
     </header>
   );

--- a/src/Article/presentational/ArticleHeader.tsx
+++ b/src/Article/presentational/ArticleHeader.tsx
@@ -26,14 +26,14 @@ const ArticleHeader = ({
       <div className="articleheader-btns">
         <button
           type="button"
-          className="articleheade-btn-update"
+          className="articleheader-btn-update"
           onClick={onUpdateArticle}
         >
           수정
         </button>
         <button
           type="button"
-          className="articleheade-btn-delete"
+          className="articleheader-btn-delete"
           onClick={onDeleteArticle}
         >
           삭제

--- a/src/RouterTest.tsx
+++ b/src/RouterTest.tsx
@@ -5,7 +5,7 @@ interface MatchParams {
   id: string;
 }
 const RouterTest = () => {
-  const { id } = useParams();
+  const { id } = useParams<{ id: string }>();
   const history = useHistory();
   console.log(id);
 


### PR DESCRIPTION
### 상세내용

- `ArticleProps` 에 `ArticleHeaderProps` 인터페이스 추가.

  - `ArticleHeaderProps` 는 `ArticleHeaderContainer` 가 `ArticleHeader` 에게 주는 props의 타입입니다. 

- `ArticleHeader` presenter에 `수정` , `삭제` 버튼 추가.
- 해당 버튼들에 `onClick` 함수 설계 완료, 콜백으로 `container`에서 수행하도록 조정.
- `useParams` 관련 { id } 값의 타입을 지정못하는 문제 해결.

  - `useParmas` 는 제네릭 타입으로, 이를 정해주어 해결.

---

### 구현 설명.

먼저 `ArticleHeaderContainer` 가 `ArticleHeader` presenter 에게 props를 주는 부분을 많이 수정했습니다. 아래와 같이요.

![image](https://user-images.githubusercontent.com/52649378/117919189-861bd700-b327-11eb-98f1-1d540bc41a19.png)

- 10번째 줄은 `수정` 버튼이 눌렸을때 일어나는 콜백 함수입니다.
- 15번째 줄은 마찬가지로, `삭제` 버튼에 해당돼요.
- 따라서, `ArticleHeaderContainer` 는 presenter 에게 이렇게 3개 props를 넘겨줘요. 

  - `onUpdateArticle` 함수, `onDeleteArticle` 함수, `articleData` 를 넘겨줍니다.

---


**이를 받는 presenter 함수를 볼게요.**

![image](https://user-images.githubusercontent.com/52649378/117919403-e3b02380-b327-11eb-922a-1ffa0e50aaee.png)

- 8번째 줄에, 받은 3개의 props에 대한 타입이 `ArticleHeaderProps` 라고 정의되어 있죵.

이는 아래 처럼 생겼어요.

![image](https://user-images.githubusercontent.com/52649378/117919488-0b9f8700-b328-11eb-96f1-fab4cbc5bc94.png)

- 다시, presenter 함수보시면 30, 37번째 줄에 클릭함수를 바인딩해놨습니다. 이게 작동되면 `ArticleHeaderContainer` 의 10번째, 15번째 줄이 수행되겠죠. **이해가나용?**

---

다음 안건입니다. 

### `useParams` 오류 해결건입니다. 

![image](https://user-images.githubusercontent.com/52649378/117919732-7ea8fd80-b328-11eb-8ac9-c6a0e2c4a7d7.png)

`: any` 가 아니라 이렇게 제네릭 타입을 지정해주는 방식인데, 이 제네릭 타입이 조금 개념이 어려울 것 같아요.

@hyunju95 님, @dayonxxi 님 두 분 모두 C++를 그래도 만져보셨을텐데, **C++ 의 템플릿 개념**이랑 비슷합니다. 

[이곳](https://joshua1988.github.io/ts/guide/generics.html#%EC%A0%9C%EB%84%A4%EB%A6%AD-generics-%EC%9D%98-%EC%82%AC%EC%A0%84%EC%A0%81-%EC%A0%95%EC%9D%98)에 정말 쉽게 알려주긴하니까 한번씩만 읽어주세요.

## 질문사항 or  이해안가는 부분은 콕콕 찝어서 comment 남겨주세요! 

 closes #37 