### PR TITLE
feature(유저) : 로그인 / 회원가입 UI 구현   

### DIFF
--- a/src/Atoms/atom.tsx
+++ b/src/Atoms/atom.tsx
@@ -56,3 +56,9 @@ export const NewCommentId = atom<number>({
   key: 'newCommentId',
   default: 0,
 });
+
+export const isFullSize = atom<boolean>({
+  key: 'isfullSize',
+  default: false,
+});
+

--- a/src/Layout/HongitHeader.tsx
+++ b/src/Layout/HongitHeader.tsx
@@ -1,35 +1,28 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Container, Grid, Header, List, Segment } from 'semantic-ui-react';
+import { Segment } from 'semantic-ui-react';
+import 'css/Layout.css';
 
 const HongitHeader = () => (
   <div>
-    <Segment inverted vertical style={{ padding: '1em 0em' }}>
-      <Container>
-        <Grid divided inverted stackable>
-          <Grid.Row>
-            <Grid.Column width={1}>
-              <Header inverted as="h4" content="HongIt" />
-              <List className="header-list" link stackable inverted>
-                <List.Item>
-                  <Link to="/">Main</Link>
-                </List.Item>
-                <List.Item>
-                  <Link to="/board">Board</Link>
-                </List.Item>
-              </List>
-            </Grid.Column>
-          </Grid.Row>
-        </Grid>
-      </Container>
+    <Segment
+      className="header-bar"
+      inverted
+      vertical
+      style={{ padding: '2em' }}
+    >
+      <Link className="hongit-link" to="/">
+        HONGIT
+      </Link>
+      <Link className="login-link" to="/login">
+        로그인
+      </Link>
     </Segment>
     <Segment
       inverted
       vertical
-      style={{ padding: '14em 0em', background: 'yellowgreen' }}
-    >
-      <Container />
-    </Segment>
+      style={{ padding: '14em 0em', background: 'crimson' }}
+    />
   </div>
 );
 

--- a/src/Layout/HongitMain.tsx
+++ b/src/Layout/HongitMain.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { isFullSize } from 'Atoms/atom';
+import { useSetRecoilState } from 'recoil'
 import {
   Button,
   Container,
@@ -8,79 +10,87 @@ import {
   Segment,
 } from 'semantic-ui-react';
 
-const HongitMain = () => (
-  <div>
-    <Segment style={{ padding: '0em' }} vertical>
-      <Grid celled="internally" columns="equal" stackable>
-        <Grid.Row textAlign="center">
-          <Grid.Column style={{ paddingBottom: '5em', paddingTop: '5em' }}>
-            <Header as="h3" style={{ fontSize: '2em' }}>
-              What a Company
-            </Header>
-            <p style={{ fontSize: '1.33em' }}>
-              That is what they all say about us
-            </p>
-          </Grid.Column>
-          <Grid.Column style={{ paddingBottom: '5em', paddingTop: '5em' }}>
-            <Header as="h3" style={{ fontSize: '2em' }}>
-              I shouldnt have gone with their competitor.
-            </Header>
-            <p style={{ fontSize: '1.33em' }}>hello hello Grid test</p>
-          </Grid.Column>
-        </Grid.Row>
-      </Grid>
-    </Segment>
-    <Segment style={{ padding: '8em 0em' }} vertical>
-      <Container text>
-        <Header as="h3" style={{ fontSize: '3em' }}>
-          Hello Hello Hongit Main Page!
-        </Header>
-        <p style={{ fontSize: '1.33em' }}>
-          Instead of focusing on content creation and hard work, we have learned
-          how to master the art of doing nothing by providing massive amounts of
-          whitespace and generic content that can seem massive, monolithic and
-          worth your attention
-        </p>
-        <Button as="a" size="large">
-          Read More
-        </Button>
-        <Divider
-          as="h4"
-          className="header"
-          horizontal
-          style={{ margin: '3em 0em', textTransform: 'uppercase' }}
-        >
-          <a href="/">Case Studies</a>
-        </Divider>
-        <Header as="h3" style={{ fontSize: '2em' }}>
-          Did We Tell You About Our Bananas?
-        </Header>
-        <p style={{ fontSize: '1.33em' }}>
-          Yes I know you probably disregarded the earlier boasts as non-sequitur
-          filler content, but its really true. It took years of gene splicing
-          and combinatory DNA research, but our bananas can really dance.
-        </p>
-        <Button as="a" size="large">
-          Button Test
-        </Button>
-      </Container>
-    </Segment>
-    <Segment style={{ padding: '3em 0em' }} vertical>
-      <Container text>
-        <Header as="h3" style={{ fontSize: '2em' }}>
-          Hongit Main Layout
-        </Header>
-        <p style={{ fontSize: '1.23em' }}>
-          Instead of focusing on content creation and hard work, we have learned
-          Yes I know you probably disregarded the earlier boasts as non-sequitur
-          how to master th 홍잇 메인화면 레이아웃 테스트
-        </p>
-        <Button as="a" size="large">
-          Read More
-        </Button>
-      </Container>
-    </Segment>
-  </div>
-);
+const HongitMain = () => {
+  const setFullSize = useSetRecoilState(isFullSize);
+
+  useEffect(() => {
+    setFullSize(false);
+  }, []);
+
+  return (
+    <div>
+      <Segment style={{ padding: '0em' }} vertical>
+        <Grid celled="internally" columns="equal" stackable>
+          <Grid.Row textAlign="center">
+            <Grid.Column style={{ paddingBottom: '5em', paddingTop: '5em' }}>
+              <Header as="h3" style={{ fontSize: '2em' }}>
+                What a Company
+              </Header>
+              <p style={{ fontSize: '1.33em' }}>
+                That is what they all say about us
+              </p>
+            </Grid.Column>
+            <Grid.Column style={{ paddingBottom: '5em', paddingTop: '5em' }}>
+              <Header as="h3" style={{ fontSize: '2em' }}>
+                I shouldnt have gone with their competitor.
+              </Header>
+              <p style={{ fontSize: '1.33em' }}>hello hello Grid test</p>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Segment>
+      <Segment style={{ padding: '8em 0em' }} vertical>
+        <Container text>
+          <Header as="h3" style={{ fontSize: '3em' }}>
+            Hello Hello Hongit Main Page!
+          </Header>
+          <p style={{ fontSize: '1.33em' }}>
+            Instead of focusing on content creation and hard work, we have learned
+            how to master the art of doing nothing by providing massive amounts of
+            whitespace and generic content that can seem massive, monolithic and
+            worth your attention
+          </p>
+          <Button as="a" size="large">
+            Read More
+          </Button>
+          <Divider
+            as="h4"
+            className="header"
+            horizontal
+            style={{ margin: '3em 0em', textTransform: 'uppercase' }}
+          >
+            <a href="/">Case Studies</a>
+          </Divider>
+          <Header as="h3" style={{ fontSize: '2em' }}>
+            Did We Tell You About Our Bananas?
+          </Header>
+          <p style={{ fontSize: '1.33em' }}>
+            Yes I know you probably disregarded the earlier boasts as non-sequitur
+            filler content, but its really true. It took years of gene splicing
+            and combinatory DNA research, but our bananas can really dance.
+          </p>
+          <Button as="a" size="large">
+            Button Test
+          </Button>
+        </Container>
+      </Segment>
+      <Segment style={{ padding: '3em 0em' }} vertical>
+        <Container text>
+          <Header as="h3" style={{ fontSize: '2em' }}>
+            Hongit Main Layout
+          </Header>
+          <p style={{ fontSize: '1.23em' }}>
+            Instead of focusing on content creation and hard work, we have learned
+            Yes I know you probably disregarded the earlier boasts as non-sequitur
+            how to master th 홍잇 메인화면 레이아웃 테스트
+          </p>
+          <Button as="a" size="large">
+            Read More
+          </Button>
+        </Container>
+      </Segment>
+    </div>
+  );
+};
 
 export default HongitMain;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { SideBarProps } from 'interface/ArgProps';
+import { isFullSize } from 'Atoms/atom';
 import ArticleDetailContainer from './Article/container/ArticleDetailContainer';
 import ArticleCreatePageContainer from './Article/container/ArticleCreatePageContainer';
 import ArticleListContainer from './ArticleList/container/ArticleListContainer';
@@ -9,11 +9,14 @@ import SidebarContainer from './Layout/SidebarContainer';
 import HongitMain from './Layout/HongitMain';
 import HongitHeader from './Layout/HongitHeader';
 import HongitFooter from './Layout/HongitFooter';
-
+import Login from './User/Login';
+import SignIn from './User/SignIn';
 import 'css/Router.css';
 
 const Router = () => (
   <div>
+    <Route path="/login" component={Login} exact />
+    <Route path="/SignIn" component={SignIn} exact />
     <HongitHeader />
     <div className="total-main">
       <div className="side-contents">

--- a/src/User/Login.tsx
+++ b/src/User/Login.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { isFullSize } from 'Atoms/atom';
+import {
+  Button,
+  Form,
+  Grid,
+  Header,
+  Message,
+  Segment,
+} from 'semantic-ui-react';
+
+import 'css/Layout.css';
+
+const Login = () => (
+  <Grid textAlign="center" style={{ height: '100vh' }} verticalAlign="middle">
+    <Grid.Column style={{ maxWidth: 450 }}>
+      <Header as="h1" color="teal" textAlign="center">
+        HONGIT
+      </Header>
+      <Form size="large">
+        <Segment stacked>
+          <Form.Input
+            fluid
+            icon="user"
+            iconPosition="left"
+            placeholder="아이디"
+          />
+          <Form.Input
+            fluid
+            icon="lock"
+            iconPosition="left"
+            placeholder="비밀번호"
+            type="password"
+          />
+          <Button color="teal" fluid size="large">
+            Login
+          </Button>
+        </Segment>
+      </Form>
+      <Message color="teal">
+        <a href="/SignIn">회원가입</a>
+      </Message>
+    </Grid.Column>
+  </Grid>
+);
+
+export default Login;

--- a/src/User/SignIn.tsx
+++ b/src/User/SignIn.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from 'react';
+import { isFullSize } from 'Atoms/atom';
+import { useSetRecoilState } from 'recoil';
+import {
+  Button,
+  Form,
+  Grid,
+  Header,
+  Segment,
+  Select,
+} from 'semantic-ui-react';
+
+const SignIn = () => {
+  const mailOptions = [
+    { key: 'g', text: '@g.hongik.ac.kr', value: '@g.hongik.ac.kr' },
+    { key: 'mail', text: '@mail.hongik.ac.kr', value: '@mail.hongik.ac.kr' },
+  ]
+
+  const stuOptions = [
+    { key: 'senior', text: '재학생', value: '재학생' },
+    { key: 'junior', text: '신입생', value: '신입생' },
+  ]
+
+  // const [isFull, setFullSize] = useRecoilState(isFullSize);
+  const setFullSize = useSetRecoilState(isFullSize);
+
+  useEffect(() => {
+    setFullSize(true);
+  }, []);
+
+  return (
+    <Grid textAlign="center" style={{ height: '100vh' }} verticalAlign="middle">
+      <Grid.Column style={{ maxWidth: 450 }}>
+        <Header color="teal" as="h2" textAlign="center">
+          회원가입
+        </Header>
+        <Form size="large">
+          <Segment stacked>
+            <Form.Input
+              fluid
+              placeholder="아이디"
+            />
+            <Form.Input
+              fluid
+              placeholder="비밀번호"
+              type="password"
+            />
+            <Form.Input
+              fluid
+              placeholder="비밀번호 확인"
+              type="password"
+            />
+            <Form.Input
+              fluid
+              placeholder="닉네임"
+            />
+            <Form.Input fluid type='text' placeholder='학번' action>
+              <input />
+              <Select options={stuOptions} defaultValue='재학생' />
+            </Form.Input>
+            <Form.Input fluid type='text' placeholder='학교메일' action>
+              <input />
+              <Select options={mailOptions} defaultValue='@g.hongik.ac.kr' />
+              <Button type='submit' color="teal">전송하기</Button>
+            </Form.Input>
+            <Form.Input
+              fluid
+              placeholder="인증번호"
+            />
+            <Button color="teal" fluid size="large">
+              회원가입
+            </Button>
+          </Segment>
+        </Form>
+      </Grid.Column>
+    </Grid>
+  );
+};
+
+export default SignIn;

--- a/src/css/Layout.css
+++ b/src/css/Layout.css
@@ -1,0 +1,19 @@
+.header-bar {
+  display: flex;
+  justify-content: space-between;
+}
+
+.hongit-link {
+  font-size: 30px;
+  color: white;
+  font-weight: 600;
+}
+.login-link {
+  font-size: 20px;
+  color: white;
+  font-weight: 600;
+}
+
+.hongit-link:hover {
+  color: crimson;
+}


### PR DESCRIPTION
로그인 회원가입 UI 구성 ( 임시!!! )

![image](https://user-images.githubusercontent.com/80870154/124384245-4bbd2d80-dd0b-11eb-82b1-c21f51725d14.png)

상단에 로그인 버튼 클릭 시, 로그인 UI 나타남 
![image](https://user-images.githubusercontent.com/80870154/124384261-5bd50d00-dd0b-11eb-9d86-c3674de90004.png)
![image](https://user-images.githubusercontent.com/80870154/124384274-6b545600-dd0b-11eb-9514-69cb15e45d70.png)

회원가입 클릭 시 회원가입 UI 나타남
![image](https://user-images.githubusercontent.com/80870154/124384291-75765480-dd0b-11eb-84be-3db263073216.png)

제가 이번주에 회사 업무가 너무 바빠서 중간중간 체크를 못할 거 같아서
우선 스프린트 진행이 편리하도록 전체적인 UI만 잡은 내용 미리 PR 날립니다!

로그인/회원가입시 헤더/푸터/사이드바를 없애는 쪽으로 하기로 했는데 Router쪽을 좀 더 봐야할 것 같아서 우선 나머지 내용들은 밑 부분에 뜨고 상단에 해당 UI만 FullSize로 뜰수 있도록 구현해 놓았습니다.