### PR TITLE
feature(회원가입): 회원가입시 비밀번호 검증

### DIFF
--- a/src/User/Presentational/SignIn.tsx
+++ b/src/User/Presentational/SignIn.tsx
@@ -1,7 +1,15 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { isFullSize } from 'Atoms/atom';
 import { useSetRecoilState } from 'recoil';
-import { Button, Form, Grid, Header, Segment, Select } from 'semantic-ui-react';
+import {
+  Button,
+  Form,
+  Grid,
+  Header,
+  Segment,
+  Select,
+  Label,
+} from 'semantic-ui-react';
 
 const SignIn = (/* {}: 새로운 타입 */) => {
   const mailOptions = [
@@ -13,6 +21,11 @@ const SignIn = (/* {}: 새로운 타입 */) => {
     { key: 'senior', text: '졸업생', value: '졸업생' },
     { key: 'junior', text: '재학생', value: '재학생' },
   ];
+
+  const [initialPwd, setInitialPwd] = useState<string>('');
+  const [pwdInputStart, setPwdInputState] = useState<boolean>(false);
+  const [checkPwd, setCheckPwd] = useState<string>('');
+  const [chkPwdInputStart, setChkPwdState] = useState<boolean>(false);
 
   // const [isFull, setFullSize] = useRecoilState(isFullSize);
   const setFullSize = useSetRecoilState(isFullSize);
@@ -30,8 +43,49 @@ const SignIn = (/* {}: 새로운 타입 */) => {
         <Form size="large">
           <Segment stacked>
             <Form.Input fluid placeholder="아이디" />
-            <Form.Input fluid placeholder="비밀번호" type="password" />
-            <Form.Input fluid placeholder="비밀번호 확인" type="password" />
+            <Form.Field>
+              <Form.Input
+                fluid
+                placeholder="비밀번호"
+                type="password"
+                onChange={(e) => {
+                  setPwdInputState(true);
+                  setInitialPwd(e.target.value);
+                }}
+                onBlur={() => setPwdInputState(false)}
+              />
+              {pwdInputStart
+                ? (initialPwd.length < 6 || initialPwd.length > 15) && (
+                    <Label basic color="red" pointing>
+                      비밀번호는 6자리 이상 15자리 이하이여야 합니다.
+                    </Label>
+                  )
+                : ``}
+            </Form.Field>
+            <Form.Field>
+              <Form.Input
+                success
+                fluid
+                placeholder="비밀번호 확인"
+                type="password"
+                onChange={(e) => {
+                  setChkPwdState(true);
+                  setCheckPwd(e.target.value);
+                }}
+                onBlur={() => setPwdInputState(false)}
+              />
+              {initialPwd === checkPwd && checkPwd.length > 0
+                ? chkPwdInputStart && (
+                    <Label basic color="green" pointing>
+                      일치합니다. 😃
+                    </Label>
+                  )
+                : chkPwdInputStart && (
+                    <Label basic color="red" pointing>
+                      비밀번호가 같지 않습니다. 🤔
+                    </Label>
+                  )}
+            </Form.Field>
             <Form.Input fluid placeholder="닉네임" />
             <Form.Input fluid type="text" placeholder="학번" action>
               <input />
@@ -45,9 +99,17 @@ const SignIn = (/* {}: 새로운 타입 */) => {
               </Button>
             </Form.Input>
             <Form.Input fluid placeholder="인증번호" />
-            <Button color="teal" fluid size="large">
-              회원가입
-            </Button>
+            {initialPwd === checkPwd &&
+            initialPwd.length >= 6 &&
+            initialPwd.length <= 15 ? (
+              <Button color="teal" fluid size="large">
+                회원가입
+              </Button>
+            ) : (
+              <Button color="teal" fluid size="large" disabled>
+                회원가입
+              </Button>
+            )}
           </Segment>
         </Form>
       </Grid.Column>


### PR DESCRIPTION
### 상세내용

![Animation1](https://user-images.githubusercontent.com/52649378/124892301-b674ae80-e014-11eb-9bed-ffcb0b375b77.gif)

- 회원가입시 유저가 입력하는 비밀번호 검증.

- 비밀번호 입력시 제한되는 사항(비밀번호 길이)들 바로바로 하단에 뜸.

- 비밀번호 확인 입력시에도 제한사항들(같지 않을때.)을 바로바로 하단에 띄움.

- 해당 제한 사항들을 충족 시켜야, 하단 회원가입 버튼이 활성화됨. **그러기전까진 클릭못함.**

---

### 구현내용 설명

특별한건 없습니다. `useState` 를 적절히 사용했고, 

삼항연산자를 사용해 구현했습니다. 

![image](https://user-images.githubusercontent.com/52649378/124892719-110e0a80-e015-11eb-8311-b2b9277e27e8.png)

다만 4가지 변수만 알려드리자면,

- 25번째줄은 처음 비밀번호를 넣을때 값입니다. 
- 26번째줄은 그 처음 비밀번호를 치기 시작할때, 상태값입니다. 처음에(아직 비번 치기전)는 `false` 를, 비번을 치기 시작하면 `true` 값을 가집니다.
- 27번째줄은 2번째 비밀번호 input, 즉 비밀번호 확인란에 들어가는 값을 기억하는 상태값입니다.
- 마찬가지로 28번째줄은 비밀번호 확인란에 입력이 시작되었는지, 상태를 기억하는 변수입니다.

질문사항있으면 질문주세요~