### PR TITLE
refactor(회원가입): 비밀번호 검증 과정 리팩토링.

### DIFF
--- a/src/Layout/HongitMain.tsx
+++ b/src/Layout/HongitMain.tsx
@@ -7,7 +7,6 @@ import BoardPreview from 'Board/presentational/BoardPreview';
 import { Grid, Segment } from 'semantic-ui-react';
 import 'css/BoardDetail.css';
 
-
 const HongitMain = () => {
   const [data, setData] = useState<HomeApi>({
     totalFavorite: {

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -70,7 +70,11 @@ const Sidebar = ({ sideBarData }: SideBarProps) => {
         {sideBarData
           .filter((board) => board.type.id === 'COURSE_BOARD')
           .map((course) => (
-            <Link to="/board" className="small-category-btn" onClick={removeBanner}>
+            <Link
+              to="/board"
+              className="small-category-btn"
+              onClick={removeBanner}
+            >
               {course.title}
             </Link>
           ))}

--- a/src/User/Presentational/SignIn.tsx
+++ b/src/User/Presentational/SignIn.tsx
@@ -24,8 +24,10 @@ const SignIn = (/* {}: 새로운 타입 */) => {
 
   const [initialPwd, setInitialPwd] = useState<string>('');
   const [pwdInputStart, setPwdInputState] = useState<boolean>(false);
+  const [pwdInputEnd, setPwdInputEndState] = useState<boolean>(false);
   const [checkPwd, setCheckPwd] = useState<string>('');
   const [chkPwdInputStart, setChkPwdState] = useState<boolean>(false);
+  const [chkPwdInputEnd, setChkPwdEndState] = useState<boolean>(false);
 
   // const [isFull, setFullSize] = useRecoilState(isFullSize);
   const setFullSize = useSetRecoilState(isFullSize);
@@ -52,11 +54,39 @@ const SignIn = (/* {}: 새로운 타입 */) => {
                   setPwdInputState(true);
                   setInitialPwd(e.target.value);
                 }}
-                onBlur={() => setPwdInputState(false)}
+                onBlur={() => {
+                  setPwdInputState(false);
+                  setPwdInputEndState(true);
+                }}
               />
               {pwdInputStart
                 ? (initialPwd.length < 6 || initialPwd.length > 15) && (
-                    <Label basic color="red" pointing>
+                    <Label
+                      style={{
+                        position: 'absolute',
+                        zIndex: '9',
+                        left: '5rem',
+                      }}
+                      basic
+                      color="red"
+                      pointing
+                    >
+                      비밀번호는 6자리 이상 15자리 이하이여야 합니다.
+                    </Label>
+                  )
+                : ``}
+              {pwdInputEnd
+                ? (initialPwd.length < 6 || initialPwd.length > 15) && (
+                    <Label
+                      style={{
+                        position: 'absolute',
+                        zIndex: '9',
+                        left: '5rem',
+                      }}
+                      basic
+                      color="red"
+                      pointing
+                    >
                       비밀번호는 6자리 이상 15자리 이하이여야 합니다.
                     </Label>
                   )
@@ -72,19 +102,56 @@ const SignIn = (/* {}: 새로운 타입 */) => {
                   setChkPwdState(true);
                   setCheckPwd(e.target.value);
                 }}
-                onBlur={() => setPwdInputState(false)}
+                onBlur={() => {
+                  setChkPwdState(false);
+                  setChkPwdEndState(true);
+                }}
               />
               {initialPwd === checkPwd && checkPwd.length > 0
                 ? chkPwdInputStart && (
-                    <Label basic color="green" pointing>
+                    <Label
+                      style={{
+                        position: 'absolute',
+                        zIndex: '9',
+                        left: '11rem',
+                      }}
+                      basic
+                      color="green"
+                      pointing
+                    >
                       일치합니다. 😃
                     </Label>
                   )
                 : chkPwdInputStart && (
-                    <Label basic color="red" pointing>
+                    <Label
+                      style={{
+                        position: 'absolute',
+                        zIndex: '9',
+                        left: '8rem',
+                      }}
+                      basic
+                      color="red"
+                      pointing
+                    >
                       비밀번호가 같지 않습니다. 🤔
                     </Label>
                   )}
+              {chkPwdInputEnd && initialPwd !== checkPwd ? (
+                <Label
+                  style={{
+                    position: 'absolute',
+                    zIndex: '9',
+                    left: '8rem',
+                  }}
+                  basic
+                  color="red"
+                  pointing
+                >
+                  비밀번호가 같지 않습니다. 🤔
+                </Label>
+              ) : (
+                ``
+              )}
             </Form.Field>
             <Form.Input fluid placeholder="닉네임" />
             <Form.Input fluid type="text" placeholder="학번" action>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -112,8 +112,8 @@ export const allLectureAPI = {
   get: () => {
     const allLectureResponse = allLectureDummyData;
     return allLectureResponse;
-  }
-}
+  },
+};
 
 export const homeAPI = {
   get: () => {

--- a/src/interface/ArgProps.tsx
+++ b/src/interface/ArgProps.tsx
@@ -58,7 +58,7 @@ export interface FavoriteLectureProps {
 export interface BoardPreviewProp {
   previewData: BoardPreviewInfo;
 }
-    
+
 export interface ArticlePreviewProp {
   previewData: ArticlePreviewInfo;
 }


### PR DESCRIPTION
### 구현 내용

- 조건 알려주는 말풍선 overlap되게 수정.
- focus가 input에서 벗어났을때, 조건이 안맞는데 말풍선 사라지는 버그 수정.

![animation3](https://user-images.githubusercontent.com/52649378/125224279-4746d500-e308-11eb-871b-2ae717d92560.gif)

---

2개 지역 상태 관리 변수 생성했습니다. 

![image](https://user-images.githubusercontent.com/52649378/125224337-680f2a80-e308-11eb-833b-30b2a158d4f9.png)

- 27번째 줄 -> 처음에는 `false` 인데, 비밀번호 처음으로 입력하고 focus 없어지면 `true` 됨. 이 변수가 `true` 인데 6자리 이하거나 15자리 이상이면  말풍선 노출. 이 변수가 `false` 이면 아무것도 노출 안함. (아래 코드 확인.)

![image](https://user-images.githubusercontent.com/52649378/125224505-bc1a0f00-e308-11eb-9ed4-4bae4ef7386d.png)


- 30번째 줄 -> 마찬가지로, 처음에는 `false` 인데, 비밀번호 확인 인풋에 입력하고 focus없어지만 `true` 가됨. 이 변수가 `true` 이고, 조건이 안맞으면 말풍선 노출. 이 변수가 `false` 이면 아무것도 노출 안함. (아래 코드 확인.)

![image](https://user-images.githubusercontent.com/52649378/125224521-c3411d00-e308-11eb-9cd3-d12583363666.png)

---

삼항연산자로 간단히 구현했습니다. 

closes #77 