### PR TITLE
refactor(즐겨찾기): 즐겨찾기 목록 상태 기억 및 CSS 수정.

### DIFF
--- a/src/FavoriteLecture/Presentational/FavoriteLecture.tsx
+++ b/src/FavoriteLecture/Presentational/FavoriteLecture.tsx
@@ -6,6 +6,8 @@ import { grade, subjectName, selectedFavorites } from 'Atoms/atom';
 import { Grid, Header, Divider, Button, Label, Icon } from 'semantic-ui-react';
 import { FavoriteLectureProps } from '../../interface/ArgProps';
 
+import '../../css/favoriteLecture.css';
+
 const FavortieLecture = ({
   yearFilteredData,
   finalFilteredData,
@@ -21,13 +23,11 @@ const FavortieLecture = ({
   const onClickYear = (e: React.MouseEvent<HTMLButtonElement>) => {
     const clickedYear = e.currentTarget.value;
     setGrade(clickedYear);
-    e.currentTarget.classList.toggle('active');
   };
 
   const onClickSubject = (e: React.MouseEvent<HTMLButtonElement>) => {
     const clickedSubject = e.currentTarget.value;
     setSubject(clickedSubject);
-    // e.currentTarget.classList.toggle('active');
   };
 
   const onClickProfessor = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -75,82 +75,68 @@ const FavortieLecture = ({
           <Divider />
           <Grid className="grid-tmp" columns={5}>
             <Grid.Column width={2} textAlign="center">
-              <Button.Group labeled toggle vertical size="large">
-                {selectedGrade.includes('1학년') ? (
-                  <Button value="1학년" color="red" onClick={onClickYear}>
-                    1학년
-                  </Button>
-                ) : (
-                  <Button
-                    value="1학년"
-                    inverted
-                    color="red"
-                    onClick={onClickYear}
-                  >
-                    1학년
-                  </Button>
-                )}
-                {selectedGrade.includes('2학년') ? (
-                  <Button value="2학년" color="blue" onClick={onClickYear}>
-                    2학년
-                  </Button>
-                ) : (
-                  <Button
-                    value="2학년"
-                    inverted
-                    color="blue"
-                    onClick={onClickYear}
-                  >
-                    2학년
-                  </Button>
-                )}
-                {selectedGrade.includes('3학년') ? (
-                  <Button value="3학년" color="green" onClick={onClickYear}>
-                    3학년
-                  </Button>
-                ) : (
-                  <Button
-                    value="3학년"
-                    inverted
-                    color="green"
-                    onClick={onClickYear}
-                  >
-                    3학년
-                  </Button>
-                )}
-                {selectedGrade.includes('4학년') ? (
-                  <Button value="4학년" color="purple" onClick={onClickYear}>
-                    4학년
-                  </Button>
-                ) : (
-                  <Button
-                    value="4학년"
-                    inverted
-                    color="purple"
-                    onClick={onClickYear}
-                  >
-                    4학년
-                  </Button>
-                )}
+              <Button.Group
+                className="fav-btn-group"
+                labeled
+                toggle
+                vertical
+                size="large"
+              >
+                <Button
+                  value="1학년"
+                  className="fav-grade"
+                  onClick={onClickYear}
+                >
+                  1학년
+                </Button>
+                <Button
+                  value="2학년"
+                  className="fav-grade"
+                  onClick={onClickYear}
+                >
+                  2학년
+                </Button>
+                <Button
+                  value="3학년"
+                  className="fav-grade"
+                  onClick={onClickYear}
+                >
+                  3학년
+                </Button>
+                <Button
+                  value="4학년"
+                  className="fav-grade"
+                  onClick={onClickYear}
+                >
+                  4학년
+                </Button>
               </Button.Group>
             </Grid.Column>
             <Grid.Column width={3} textAlign="center">
-              <Button.Group vertical>
+              <Button.Group className="fav-btn-group" vertical>
                 {yearFilteredData.length === 0
                   ? ``
                   : yearFilteredData.map((data) => (
-                      <Button value={data} onClick={onClickSubject}>
+                      <Button
+                        className="fav-subject"
+                        value={data}
+                        onClick={onClickSubject}
+                      >
                         {data}
                       </Button>
                     ))}
               </Button.Group>
             </Grid.Column>
             <Grid.Column centered width={2} textAlign="center">
-              <Button.Group toggle vertical>
+              <Button.Group className="fav-btn-group" toggle vertical>
                 {finalFilteredData.length === 0
                   ? ``
                   : finalFilteredData.map((data) => (
-                      <Button value={data} onClick={onClickProfessor}>
+                      <Button
+                        className="fav-professor"
+                        value={data}
+                        onClick={onClickProfessor}
+                      >
                         {data}
                       </Button>
                     ))}
@@ -160,7 +146,12 @@ const FavortieLecture = ({
               {selectedCombination.length === 0
                 ? ``
                 : selectedCombination.map((combi) => (
-                    <Label style={{ margin: '0.5rem 0' }} tag value={combi}>
+                    <Label
+                      className="tmptmp"
+                      style={{ margin: '0.5rem 0' }}
+                      tag
+                      value={combi}
+                    >
                       {combi}
                       <Icon name="delete" onClick={onRemoveFavTag} />
                     </Label>
@@ -168,9 +159,19 @@ const FavortieLecture = ({
             </Grid.Column>
             <Grid.Column centered width={2} textAlign="center">
               {selectedCombination.length === 0 ? (
-                <Button disabled>추가</Button>
+                <Button
+                  style={{ backgroundColor: 'slategray', color: 'white' }}
+                  disabled
+                >
+                  추가
+                </Button>
               ) : (
-                <Button onClick={onRegisterFavorite}>추가</Button>
+                <Button
+                  style={{ backgroundColor: 'black', color: 'white' }}
+                  onClick={onRegisterFavorite}
+                >
+                  추가
+                </Button>
               )}
             </Grid.Column>
           </Grid>

--- a/src/FavoriteLecture/Presentational/FavoriteLecture.tsx
+++ b/src/FavoriteLecture/Presentational/FavoriteLecture.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, SyntheticEvent } from 'react';
 
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
 import { grade, subjectName, selectedFavorites } from 'Atoms/atom';
 
 import { Grid, Header, Divider, Button, Label, Icon } from 'semantic-ui-react';
@@ -13,7 +13,7 @@ const FavortieLecture = ({
   finalFilteredData,
   onAddSiderBars,
 }: FavoriteLectureProps) => {
-  const [selectedGrade, setGrade] = useRecoilState(grade);
+  const setGrade = useSetRecoilState(grade);
   const [selectedSubject, setSubject] = useRecoilState(subjectName);
   const alreadyFavoritesSidebar = useRecoilValue(selectedFavorites);
 
@@ -146,12 +146,7 @@ const FavortieLecture = ({
               {selectedCombination.length === 0
                 ? ``
                 : selectedCombination.map((combi) => (
-                    <Label
-                      className="tmptmp"
-                      style={{ margin: '0.5rem 0' }}
-                      tag
-                      value={combi}
-                    >
+                    <Label style={{ margin: '0.5rem 0' }} tag value={combi}>
                       {combi}
                       <Icon name="delete" onClick={onRemoveFavTag} />
                     </Label>

--- a/src/FavoriteLecture/Presentational/FavoriteLecture.tsx
+++ b/src/FavoriteLecture/Presentational/FavoriteLecture.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, SyntheticEvent } from 'react';
 
-import { useRecoilState } from 'recoil';
-import { grade, subjectName } from 'Atoms/atom';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { grade, subjectName, selectedFavorites } from 'Atoms/atom';
 
 import { Grid, Header, Divider, Button, Label, Icon } from 'semantic-ui-react';
 import { FavoriteLectureProps } from '../../interface/ArgProps';
@@ -13,6 +13,7 @@ const FavortieLecture = ({
 }: FavoriteLectureProps) => {
   const [selectedGrade, setGrade] = useRecoilState(grade);
   const [selectedSubject, setSubject] = useRecoilState(subjectName);
+  const alreadyFavoritesSidebar = useRecoilValue(selectedFavorites);
 
   const [selectedProfessor, setProfProfessor] = useState<string>('');
   const [selectedCombination, setCombination] = useState<string[]>([]);
@@ -36,7 +37,6 @@ const FavortieLecture = ({
 
   const onRemoveFavTag = (e: SyntheticEvent) => {
     const clickedValue = e.currentTarget.parentElement?.textContent;
-    console.log(e.currentTarget.parentElement?.textContent);
     setCombination(() =>
       selectedCombination.filter((combi) => combi !== clickedValue)
     );
@@ -57,7 +57,15 @@ const FavortieLecture = ({
       setCombination([...selectedCombination, addItem]);
     }
     setProfProfessor('');
-  }, [selectedProfessor]);
+  }, [selectedProfessor, selectedCombination, selectedSubject]);
+
+  useEffect(() => {
+    if (alreadyFavoritesSidebar.length > 0) {
+      setCombination(() =>
+        alreadyFavoritesSidebar.map((favLecture) => `${favLecture.title}`)
+      );
+    }
+  }, [alreadyFavoritesSidebar]);
 
   return (
     <Grid container style={{ padding: '2em 0em' }}>

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -44,9 +44,7 @@ const Sidebar = ({ sideBarData }: SideBarProps) => {
       </button>
       <nav className={favLectureSubNav ? 'subNav-active' : 'subNav'}>
         <Link to="/favoriteRegister" className="favorite-add-btn">
-          <button className="favorite-add-btn" type="button">
-            즐겨찾기 추가
-          </button>
+          즐겨찾기 추가
         </Link>
         {favoriteLectures.map((lecture) => (
           <Link to={`/board/${lecture.id}`} className="small-category-btn">

--- a/src/css/Sidebar.css
+++ b/src/css/Sidebar.css
@@ -80,7 +80,7 @@
 .favorite-add-btn {
   background: crimson;
   font-weight: 600;
-  padding-left: 0.5rem;
+  padding-left: 1.3rem;
   height: 40px;
   margin: 0.2rem;
   display: flex;
@@ -93,6 +93,7 @@
   font-size: 12px;
 }
 
-.favorite-add-btn :hover {
-  background: black;
+.favorite-add-btn:hover {
+  transform: scale(1.1);
+  color: white;
 }

--- a/src/css/favoriteLecture.css
+++ b/src/css/favoriteLecture.css
@@ -22,10 +22,6 @@ Button.fav-professor:nth-child(2n) {
   background-color: #c9e4c5;
 }
 
-Label.tmptmp {
-  background-color: teal;
-}
-
 .fav-btn-group {
   border: 1px solid white;
 }

--- a/src/css/favoriteLecture.css
+++ b/src/css/favoriteLecture.css
@@ -1,0 +1,31 @@
+Button.fav-grade:nth-child(2n + 1) {
+  background-color: whitesmoke;
+}
+
+Button.fav-grade:nth-child(2n) {
+  background-color: #cdf0ea;
+}
+
+Button.fav-subject:nth-child(2n + 1) {
+  background-color: #a2dbf9;
+}
+
+Button.fav-subject:nth-child(2n) {
+  background-color: white;
+}
+
+Button.fav-professor:nth-child(2n + 1) {
+  background-color: #e9f6ef;
+}
+
+Button.fav-professor:nth-child(2n) {
+  background-color: #c9e4c5;
+}
+
+Label.tmptmp {
+  background-color: teal;
+}
+
+.fav-btn-group {
+  border: 1px solid white;
+}


### PR DESCRIPTION
### 상세내용

- 즐겨찾기를 추가해서 왼쪽 사이드바에 추가되고 나서, 다른데 갔다가 다시 즐겨찾기 추가 누르면
  우측에 태그가 존재하지 않았음. (내가 이미 추가한거가 태그로 안떴음.)

- 해당 버그 상태 기억해서 렌더링하도록 버그 수정.

- 못생긴 UI 개선. -> 색 관련 정할 것은 의견 수렴 필요.

---

### 구현내용

특별한건 없어요! 

`useEffect` 를 통해서 상태를 기억하여, 이를 렌더링 했습니다.
