### PR TITLE
refactor(게시판 목록 조회): API 명세 업데이트 반영

### DIFF
--- a/src/api/ApiProps.tsx
+++ b/src/api/ApiProps.tsx
@@ -120,6 +120,10 @@ export interface SideBarDetailApi {
     id: string;
     text: string;
   };
+  grade: {
+    id: string;
+    text: string;
+  }
 }
 
 export interface AllLectureDetailApi {

--- a/src/api/ApiProps.tsx
+++ b/src/api/ApiProps.tsx
@@ -123,7 +123,7 @@ export interface SideBarDetailApi {
   grade: {
     id: string;
     text: string;
-  }
+  };
 }
 
 export interface AllLectureDetailApi {

--- a/src/api/ApiProps.tsx
+++ b/src/api/ApiProps.tsx
@@ -123,7 +123,7 @@ export interface SideBarDetailApi {
   grade: {
     id: string;
     text: string;
-  };
+  } | null;
 }
 
 export interface AllLectureDetailApi {

--- a/src/data/SideBarDummyData.ts
+++ b/src/data/SideBarDummyData.ts
@@ -8,8 +8,8 @@ const sidebarDummyData = [
     },
     grade: {
       id: 'FRESHMAN',
-      text: '1학년'
-    }
+      text: '1학년',
+    },
   },
   {
     id: 2,
@@ -20,8 +20,8 @@ const sidebarDummyData = [
     },
     grade: {
       id: 'FRESHMAN',
-      text: '1학년'
-    }
+      text: '1학년',
+    },
   },
   {
     id: 3,
@@ -32,8 +32,8 @@ const sidebarDummyData = [
     },
     grade: {
       id: 'SOPHOMORE',
-      text: '2학년'
-    }
+      text: '2학년',
+    },
   },
   {
     id: 4,
@@ -45,7 +45,7 @@ const sidebarDummyData = [
     grade: {
       id: 'SOPHOMORE',
       text: '2학년',
-    }
+    },
   },
   {
     id: 5,
@@ -57,7 +57,7 @@ const sidebarDummyData = [
     grade: {
       id: 'JUNIOR',
       text: '3학년',
-    }
+    },
   },
   {
     id: 6,
@@ -69,7 +69,7 @@ const sidebarDummyData = [
     grade: {
       id: 'JUNIOR',
       text: '3학년',
-    }
+    },
   },
   {
     id: 7,
@@ -81,7 +81,7 @@ const sidebarDummyData = [
     grade: {
       id: 'SENIOR',
       text: '4학년',
-    }
+    },
   },
   {
     id: 8,
@@ -93,7 +93,7 @@ const sidebarDummyData = [
     grade: {
       id: 'SENIOR',
       text: '4학년',
-    }
+    },
   },
   {
     id: 9,
@@ -105,7 +105,7 @@ const sidebarDummyData = [
     grade: {
       id: '',
       text: '',
-    }
+    },
   },
   {
     id: 10,
@@ -117,7 +117,7 @@ const sidebarDummyData = [
     grade: {
       id: '',
       text: '',
-    }
+    },
   },
   {
     id: 11,
@@ -129,7 +129,7 @@ const sidebarDummyData = [
     grade: {
       id: '',
       text: '',
-    }
+    },
   },
   {
     id: 12,
@@ -141,7 +141,7 @@ const sidebarDummyData = [
     grade: {
       id: '',
       text: '',
-    }
+    },
   },
 ];
 

--- a/src/data/SideBarDummyData.ts
+++ b/src/data/SideBarDummyData.ts
@@ -102,10 +102,7 @@ const sidebarDummyData = [
       id: 'QNA_BOARD',
       text: '질문게시판',
     },
-    grade: {
-      id: '',
-      text: '',
-    },
+    grade: null,
   },
   {
     id: 10,
@@ -114,10 +111,7 @@ const sidebarDummyData = [
       id: 'COMMUNITY_BOARD',
       text: '커뮤니티게시판',
     },
-    grade: {
-      id: '',
-      text: '',
-    },
+    grade: null,
   },
   {
     id: 11,
@@ -126,10 +120,7 @@ const sidebarDummyData = [
       id: 'GATHERING_BOARD',
       text: '구인게시판',
     },
-    grade: {
-      id: '',
-      text: '',
-    },
+    grade: null,
   },
   {
     id: 12,
@@ -138,10 +129,7 @@ const sidebarDummyData = [
       id: 'RECRUIT_BOARD',
       text: '채용게시판',
     },
-    grade: {
-      id: '',
-      text: '',
-    },
+    grade: null,
   },
 ];
 

--- a/src/data/SideBarDummyData.ts
+++ b/src/data/SideBarDummyData.ts
@@ -6,6 +6,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'FRESHMAN',
+      text: '1학년'
+    }
   },
   {
     id: 2,
@@ -14,6 +18,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'FRESHMAN',
+      text: '1학년'
+    }
   },
   {
     id: 3,
@@ -22,6 +30,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'SOPHOMORE',
+      text: '2학년'
+    }
   },
   {
     id: 4,
@@ -30,6 +42,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'SOPHOMORE',
+      text: '2학년',
+    }
   },
   {
     id: 5,
@@ -38,6 +54,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'JUNIOR',
+      text: '3학년',
+    }
   },
   {
     id: 6,
@@ -46,6 +66,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'JUNIOR',
+      text: '3학년',
+    }
   },
   {
     id: 7,
@@ -54,6 +78,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'SENIOR',
+      text: '4학년',
+    }
   },
   {
     id: 8,
@@ -62,6 +90,10 @@ const sidebarDummyData = [
       id: 'COURSE_BOARD',
       text: '수업게시판',
     },
+    grade: {
+      id: 'SENIOR',
+      text: '4학년',
+    }
   },
   {
     id: 9,
@@ -70,6 +102,10 @@ const sidebarDummyData = [
       id: 'QNA_BOARD',
       text: '질문게시판',
     },
+    grade: {
+      id: '',
+      text: '',
+    }
   },
   {
     id: 10,
@@ -78,6 +114,10 @@ const sidebarDummyData = [
       id: 'COMMUNITY_BOARD',
       text: '커뮤니티게시판',
     },
+    grade: {
+      id: '',
+      text: '',
+    }
   },
   {
     id: 11,
@@ -86,6 +126,10 @@ const sidebarDummyData = [
       id: 'GATHERING_BOARD',
       text: '구인게시판',
     },
+    grade: {
+      id: '',
+      text: '',
+    }
   },
   {
     id: 12,
@@ -94,6 +138,10 @@ const sidebarDummyData = [
       id: 'RECRUIT_BOARD',
       text: '채용게시판',
     },
+    grade: {
+      id: '',
+      text: '',
+    }
   },
 ];
 


### PR DESCRIPTION
### **상세내용**

> 우선 `ApiProps`에서 `SideBarDetailApi`의 변경된 부분을 수정했습니다!

> 수정된 `ApiProps`에 맞게 dummydata를 바꿔봤는데 `grade`가 nullablale type인 것을 감안했을 때 이러한 형태로 들어오는게 맞을까요?
![image](https://user-images.githubusercontent.com/62105312/132117534-da8df336-7a68-48c3-bab6-3979a9807a8e.png)


> 그리고 request URL을 연결하고 비어러? 그걸로 token을 전달받아햐 하는걸로 노션에 나와있는데 이건 추후에 진행해야하는게 맞을까요..? 지금 바로 할 수 있는 부분이라면 현주님 pr 참고하여 같은 방식으로 수정하겠습니다!

바뀐 부분이 너무 없어서 이게 맞나 싶어요... :(

closes #104 