### PR TITLE
feature(api): 즐겨찾기 관련 api 수정.

### DIFF
--- a/src/Article/container/CommentContainer.tsx
+++ b/src/Article/container/CommentContainer.tsx
@@ -45,7 +45,7 @@ const CommentContainer = ({ articleId }: ArticleDetailID) => {
   };
 
   const onRegisterDeleteComment = async (deleteId: number) => {
-    commentsAPI.registerDeleteComment(deleteId)
+    commentsAPI.registerDeleteComment(deleteId);
     setComments(comments.filter((comment) => comment.id !== deleteId));
   };
 

--- a/src/Board/container/AllLectureMenuContainer.tsx
+++ b/src/Board/container/AllLectureMenuContainer.tsx
@@ -10,7 +10,6 @@ const AllLectureMenuContainer = () => {
   );
 
   const loadData = async () => {
-    // FIX ME - FIXED
     const totalLectureInfo = await boardAPI.getAllLectures();
     totalLectureInfo && setAllLectureData(totalLectureInfo);
   };

--- a/src/Board/container/AllLectureMenuContainer.tsx
+++ b/src/Board/container/AllLectureMenuContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import { allLectureAPI } from 'api/api';
+import { boardAPI } from 'api/api';
 import { BoardDetailApi as AllLectureDetailApi } from 'api/ApiProps';
 import AllLectureMenu from '../presentational/AllLectureMenu';
 
@@ -10,9 +10,9 @@ const AllLectureMenuContainer = () => {
   );
 
   const loadData = async () => {
-    // FIX ME
-    const totalLectureInfo = await allLectureAPI.get();
-    setAllLectureData(totalLectureInfo);
+    // FIX ME - FIXED
+    const totalLectureInfo = await boardAPI.getAllLectures();
+    totalLectureInfo && setAllLectureData(totalLectureInfo);
   };
 
   useEffect(() => {

--- a/src/Board/container/MyLectureContainer.tsx
+++ b/src/Board/container/MyLectureContainer.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { grade, subjectName, selectedMyLectures } from 'Atoms/atom';
 
-import { allLectureAPI, sidebarAPI } from 'api/api';
+import { boardAPI, sidebarAPI } from 'api/api';
 import { BoardDetailApi as AllLectureInfosApi } from 'api/ApiProps';
 import MyLecture from '../presentational/MyLecture';
 
@@ -21,8 +21,8 @@ const MyLectureContainer = () => {
   const setMyLectures = useSetRecoilState(selectedMyLectures);
 
   const loadData = async () => {
-    // FIX ME
-    const totalLectureInfo = await allLectureAPI.get();
+    // FIX ME - FIXED
+    const totalLectureInfo = await boardAPI.getAllLectures();
     setAllLectureData(totalLectureInfo);
   };
 

--- a/src/Board/container/MyLectureContainer.tsx
+++ b/src/Board/container/MyLectureContainer.tsx
@@ -21,7 +21,6 @@ const MyLectureContainer = () => {
   const setMyLectures = useSetRecoilState(selectedMyLectures);
 
   const loadData = async () => {
-    // FIX ME - FIXED
     const totalLectureInfo = await boardAPI.getAllLectures();
     totalLectureInfo && setAllLectureData(totalLectureInfo);
   };
@@ -32,7 +31,6 @@ const MyLectureContainer = () => {
     );
     const selectedMyLectureIds = selectedFavoriteLecture.map((lec) => lec.id);
     setMyLectures(selectedFavoriteLecture);
-    // FIX ME - FIXED.
     sidebarAPI.putMyLecture(selectedMyLectureIds);
   };
 

--- a/src/Board/container/MyLectureContainer.tsx
+++ b/src/Board/container/MyLectureContainer.tsx
@@ -23,7 +23,7 @@ const MyLectureContainer = () => {
   const loadData = async () => {
     // FIX ME - FIXED
     const totalLectureInfo = await boardAPI.getAllLectures();
-    setAllLectureData(totalLectureInfo);
+    totalLectureInfo && setAllLectureData(totalLectureInfo);
   };
 
   const onAddMyLecture = (lectures: string[]) => {

--- a/src/Board/container/MyLectureContainer.tsx
+++ b/src/Board/container/MyLectureContainer.tsx
@@ -32,7 +32,7 @@ const MyLectureContainer = () => {
     );
     const selectedMyLectureIds = selectedFavoriteLecture.map((lec) => lec.id);
     setMyLectures(selectedFavoriteLecture);
-    // FIX ME
+    // FIX ME - FIXED.
     sidebarAPI.putMyLecture(selectedMyLectureIds);
   };
 

--- a/src/Board/presentational/MyLecture.tsx
+++ b/src/Board/presentational/MyLecture.tsx
@@ -19,7 +19,9 @@ const MyLecture = ({
   const alreadyInSidebar = useRecoilValue(selectedMyLectures);
 
   const [selectedProfessor, setProfProfessor] = useState<string>('');
-  const [selectedCombination, setCombination] = useState<string[]>([]);
+  const [selectedCombination, setCombination] = useState<string[]>(
+    alreadyInSidebar.map((lec) => lec.title)
+  );
 
   const onClickYear = (e: React.MouseEvent<HTMLButtonElement>) => {
     const clickedYear = e.currentTarget.value;

--- a/src/Layout/Container/SidebarContainer.tsx
+++ b/src/Layout/Container/SidebarContainer.tsx
@@ -10,16 +10,11 @@ const SidebarContainer = () => {
 
   const loadData = async () => {
     const response = await sidebarAPI.getSidebarInfos(/* sidebar */);
-    if(response === undefined) {
+    if (response === undefined) {
       console.error('Error in getting user board infos');
     } else {
       setSidebarData(response);
     }
-  };
-
-  const onModifyMyLectures = (e: any) => {
-    console.log('Modify data here.');
-    console.log(e.target.value);
   };
 
   useEffect(() => {
@@ -29,10 +24,7 @@ const SidebarContainer = () => {
   return (
     <div className="main">
       <section className="side-bar">
-        <Sidebar
-          sideBarData={sidebarData}
-          onModifyMyLectures={onModifyMyLectures}
-        />
+        <Sidebar sideBarData={sidebarData} />
       </section>
     </div>
   );

--- a/src/Layout/Container/SidebarContainer.tsx
+++ b/src/Layout/Container/SidebarContainer.tsx
@@ -9,9 +9,12 @@ const SidebarContainer = () => {
   const [sidebarData, setSidebarData] = useState<SideBarDetailApi[]>([]);
 
   const loadData = async () => {
-    // FIX ME
-    const response = await sidebarAPI.get(/* sidebar */);
-    setSidebarData(response);
+    const response = await sidebarAPI.getSidebarInfos(/* sidebar */);
+    if(response === undefined) {
+      console.error('Error in getting user board infos');
+    } else {
+      setSidebarData(response);
+    }
   };
 
   const onModifyMyLectures = (e: any) => {

--- a/src/Layout/Presentational/Sidebar.tsx
+++ b/src/Layout/Presentational/Sidebar.tsx
@@ -8,7 +8,7 @@ import { SideBarProps } from 'interface/ArgProps';
 import { v4 as uuidv4 } from 'uuid';
 import 'css/Sidebar.css';
 
-const Sidebar = ({ sideBarData, onModifyMyLectures }: SideBarProps) => {
+const Sidebar = ({ sideBarData }: SideBarProps) => {
   const [myLectureSubNav, setMyLectureSubNav] = useState(false);
   const showMyLectureSubNav = () => setMyLectureSubNav(!myLectureSubNav);
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -154,6 +154,15 @@ export const boardAPI = {
     const res = await getRequest(`${BOARD_URL}/${boardId}`);
     return res;
   },
+  getAllLectures: async () => {
+    try {
+      const res = await getRequest(`${BOARD_URL}/?type=COURSE_BOARD`);
+      return res;
+    } catch (e) {
+      console.log(e);
+      return undefined;
+    }
+  },
 };
 
 export const sidebarAPI = {
@@ -177,7 +186,7 @@ export const sidebarAPI = {
   putMyLecture: async (data: number[]) => {
     const token = window.localStorage.getItem('token');
     try {
-      const response = await putRequest(`${BOARD_URL}`, data, {
+      const response = await putRequest(`${BOARD_URL}/bookmarks`, data, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -183,7 +183,7 @@ export const sidebarAPI = {
         },
       });
       console.log(response.data);
-    } catch(e){
+    } catch (e) {
       console.log(e);
     }
   },

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { CommentApi, ArticleCreateApi } from './ApiProps';
+import { CommentApi, ArticleCreateApi, SideBarDetailApi } from './ApiProps';
 import commentListDummyData from '../data/CommentListDummyData';
 import boardDetailDummyData from '../data/BoardDetailDummyData';
 import homeDummyData from '../data/HomeDummyData';
@@ -43,9 +43,9 @@ export const postArticleRequest = async (
   }
 };
 
-export const putRequest = async (url: string, data: any) => {
+export const putRequest = async (url: string, data: any, headers: any) => {
   try {
-    const response = await axios.put(url, data);
+    const response = await axios.put(url, data, headers);
     if (response.status === 404) {
       throw Error('There would be error in requesting.');
     }
@@ -87,10 +87,10 @@ export const commentsAPI = {
     // const commentPuts = await putRequest(`${END_POINT}/`, data);
     console.log('========COMMENTS PUT API CALL========');
   },
-  registerNewComment: async(newComment: CommentApi, articleID: string) => {
+  registerNewComment: async (newComment: CommentApi, articleID: string) => {
     const token = window.localStorage.getItem('token');
 
-    try{
+    try {
       await axios.post(
         `${API_URL}/comments`,
         {
@@ -104,14 +104,14 @@ export const commentsAPI = {
           },
         }
       );
-    } catch(e) {
+    } catch (e) {
       console.log(e);
     }
   },
-  registerUpdateComment: async(updateComment: CommentApi) => {
+  registerUpdateComment: async (updateComment: CommentApi) => {
     const token = window.localStorage.getItem('token');
 
-    try{
+    try {
       await axios.post(
         `${API_URL}/comments/${updateComment.id}`,
         {
@@ -123,25 +123,22 @@ export const commentsAPI = {
           },
         }
       );
-    } catch(e){
+    } catch (e) {
       console.log(e);
     }
   },
-  registerDeleteComment: async(deleteId: number) => {
+  registerDeleteComment: async (deleteId: number) => {
     const token = window.localStorage.getItem('token');
     try {
-      await axios.delete(
-        `${API_URL}/comments/${deleteId}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-    } catch(e){
+      await axios.delete(`${API_URL}/comments/${deleteId}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    } catch (e) {
       console.log(e);
     }
-  }
+  },
 };
 
 export const boardAPI = {
@@ -160,15 +157,35 @@ export const boardAPI = {
 };
 
 export const sidebarAPI = {
-  get: () => {
-    const sideBarResponse = sidebarDummyData;
-    return sideBarResponse;
+  getSidebarInfos: async (): Promise<SideBarDetailApi[] | undefined> => {
+    const token = window.localStorage.getItem('token');
+    try {
+      const response = await axios.get(`${BOARD_URL}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const { data } = response;
+      console.log(data);
+      return data;
+    } catch (e) {
+      console.log(e);
+      return undefined;
+    }
   },
 
-  putMyLecture: (data: number[]) => {
-    // const response = await putRequest(`${END_POINT}/boards/bookmarks`);
-    console.log('========My Lecture PUT API CALL========');
-    console.log(data);
+  putMyLecture: async (data: number[]) => {
+    const token = window.localStorage.getItem('token');
+    try {
+      const response = await putRequest(`${BOARD_URL}`, data, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      console.log(response.data);
+    } catch(e){
+      console.log(e);
+    }
   },
 };
 

--- a/src/interface/ArgProps.tsx
+++ b/src/interface/ArgProps.tsx
@@ -58,7 +58,6 @@ export interface BoardDetailProp {
 
 export interface SideBarProps {
   sideBarData: SideBarDetailApi[];
-  onModifyMyLectures: (e: any) => void;
 }
 
 export interface HongitMainProps {


### PR DESCRIPTION
### 구현 내용

- 즐겨찾기 api token 추가.
- 전체 강의 정보 가져오는 api 추가.

### 상세내용

![image](https://user-images.githubusercontent.com/52649378/134844338-934a26eb-a43e-4fac-bc56-cf7330ab232a.png)

- 157번째 줄이 전체 강의 목록을 가져옵니다.

![image](https://user-images.githubusercontent.com/52649378/134844364-de6a816b-ba59-4f9b-9082-5568ea1db4e0.png)

- 169번째 줄이 사이드바에 존재하는 모든 정보들을 (즐겨찾기 포함) 싹 긁어 가져와요.
- 186번째 줄은 사용자가 즐겨찾기 수정할때, 작동됩니다. 

closes #115 